### PR TITLE
added a mime type tracker so that PDF tabs can be uploaded

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -18,7 +18,9 @@
   "permissions": [
     "background",
     "storage",
-    "activeTab"
+    "activeTab",
+    "webRequest",
+    "*://*/*"
   ],
   "options_ui": {
     "page": "options.html",


### PR DESCRIPTION
Closes #1.

The content script was not being injected on PDF tabs, however if we track the mime type of the tabs, we can then upload the PDF just from the URL rather than needing the content script. 

This performs the same as before when it's not a detected PDF tab.
